### PR TITLE
Hash updates and minor cleanup

### DIFF
--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -1,6 +1,6 @@
 {
-  "JSON Version": "1.1.1",
-  "JSON Date": "2023-04-17",
+  "JSON Version": "1.1.2",
+  "JSON Date": "2023-04-18",
   "Bases": {
     "Kitavali": {
       "Original": {
@@ -47,7 +47,7 @@
         "Name": "Rosa'vali",
         "Creator": "Rosebur",
         "Introducer": "Happyrobot33",
-        "Hash": ["796905830"],
+        "Hash": ["796905830", "1582207921v2"],
         "Weight": 1,
         "WingtipOffset": 3
       }
@@ -127,7 +127,7 @@
         "Name": "Pooltoy Da'vali",
         "Creator": "Maitake Inu",
         "Introducer": "Happyrobot33",
-        "Hash": ["793746283"],
+        "Hash": ["793746283", "2014277989v2"],
         "Weight": 1,
         "WingtipOffset": 1.54
       }
@@ -233,7 +233,7 @@
         "Name": "Reverse Avali",
         "Creator": "VictonRoy / farfelu",
         "Introducer": "Heather May",
-        "Hash": ["-1626905308"],
+        "Hash": ["-1626905308", "-1731617419v2"],
         "Weight": 1,
         "WingtipOffset": 2.28
       },
@@ -291,7 +291,7 @@
         "Name": "Shade Owl",
         "Creator": "ForestWind",
         "Introducer": "Happyrobot33",
-        "Hash": ["-1760031171"],
+        "Hash": ["-1760031171", "-1469156464v2"],
         "Weight": 1,
         "WingtipOffset": 9.74
       }
@@ -300,8 +300,8 @@
       "1.1": {
         "Name": "Flutevali v1.1",
         "Creator": "FluteBirdie",
-        "Introducer": "Happyrobot33",
-        "Hash": ["2146477889"],
+        "Introducer": "Heather May",
+        "Hash": ["2146477889", "826883716v2"],
         "Weight": 1,
         "WingtipOffset": 3.71
       },
@@ -316,8 +316,8 @@
       "2 Beta": {
         "Name": "Flutevali v2 Beta",
         "Creator": "FluteBirdie",
-        "Introducer": "Happyrobot33",
-        "Hash": ["-1268029923"],
+        "Introducer": "Heather May",
+        "Hash": ["-1268029923", "-303321714v2"],
         "Weight": 1,
         "WingtipOffset": 7.16
       }
@@ -327,7 +327,7 @@
         "Name": "Chipori",
         "Creator": "Hobbert",
         "Introducer": "DatGek",
-        "Hash": ["-455940531"],
+        "Hash": ["-455940531", "1847064403v2"],
         "Weight": 1,
         "WingtipOffset": 3.81
       }
@@ -407,7 +407,7 @@
         "Name": "Harmir",
         "Creator": "Teaf",
         "Introducer": "Heather May",
-        "Hash": ["990258841"],
+        "Hash": ["990258841", "-2007130624v2"],
         "Weight": 1,
         "WingtipOffset": 7.59
       }
@@ -417,7 +417,7 @@
         "Name": "Nico",
         "Creator": "Tokiha (Gin Karasawa)",
         "Introducer": "Heather May",
-        "Hash": ["-1646371832"],
+        "Hash": ["-1646371832", "-618014635v2"],
         "Weight": 1,
         "WingtipOffset": 5.79
       }
@@ -427,7 +427,7 @@
         "Name": "Sufosni",
         "Creator": "aokuro",
         "Introducer": "Heather May",
-        "Hash": ["-669475792"],
+        "Hash": ["-669475792", "1522500207v2"],
         "Weight": 1,
         "WingtipOffset": 5.69
       }
@@ -437,7 +437,7 @@
         "Name": "Milnunu / Milnonu",
         "Creator": "aokuro",
         "Introducer": "Heather May",
-        "Hash": ["-1677961767"],
+        "Hash": ["-1677961767", "1925790033v2"],
         "Weight": 1,
         "WingtipOffset": 3.65
       },
@@ -445,7 +445,7 @@
         "Name": "Milnunu SD / Milnonu SD",
         "Creator": "aokuro",
         "Introducer": "Heather May",
-        "Hash": ["1289562385"],
+        "Hash": ["1289562385", "1376157598v2"],
         "Weight": 1,
         "WingtipOffset": 7.7
       }
@@ -455,7 +455,7 @@
         "Name": "Milnenu",
         "Creator": "aokuro",
         "Introducer": "Heather May",
-        "Hash": ["-866797105"],
+        "Hash": ["-866797105", "-1186408428v2"],
         "Weight": 1,
         "WingtipOffset": 4.53
       },
@@ -463,7 +463,7 @@
         "Name": "Milnenu SD",
         "Creator": "aokuro",
         "Introducer": "Heather May",
-        "Hash": ["897116218"],
+        "Hash": ["897116218", "-336806613v2"],
         "Weight": 1,
         "WingtipOffset": 7.12
       }
@@ -473,7 +473,7 @@
         "Name": "Nenon / Nunon",
         "Creator": "aokuro",
         "Introducer": "Heather May",
-        "Hash": ["-270171062"],
+        "Hash": ["-270171062", "-1241705933v2"],
         "Weight": 1,
         "WingtipOffset": 4.55
       },
@@ -481,7 +481,7 @@
         "Name": "Nenon SD",
         "Creator": "aokuro",
         "Introducer": "Heather May",
-        "Hash": ["1156948191"],
+        "Hash": ["1156948191", "1829445921v2"],
         "Weight": 1,
         "WingtipOffset": 11.9
       },
@@ -489,7 +489,7 @@
         "Name": "Nunon SD",
         "Creator": "aokuro",
         "Introducer": "Heather May",
-        "Hash": ["-1805727021"],
+        "Hash": ["-1805727021", "-1198798216v2"],
         "Weight": 1,
         "WingtipOffset": 9.98
       }
@@ -499,7 +499,7 @@
         "Name": "2 or 4 Eyed Owl",
         "Creator": "Space Birb",
         "Introducer": "Heather May",
-        "Hash": ["1312830463"],
+        "Hash": ["1312830463", "1507547534v2"],
         "Weight": 1,
         "WingtipOffset": 2.0
       }
@@ -509,7 +509,7 @@
         "Name": "Kuda's Avian",
         "Creator": "Kudalyn's Creations",
         "Introducer": "Heather May",
-        "Hash": ["-1554273372"],
+        "Hash": ["-1554273372", "718666137v2"],
         "Weight": 1,
         "WingtipOffset": 4.16
       }
@@ -519,7 +519,7 @@
         "Name": "Avigen",
         "Creator": "Mike Da Bird",
         "Introducer": "Heather May",
-        "Hash": ["1121578396"],
+        "Hash": ["1121578396", "-1218808282v2"],
         "Weight": 1,
         "WingtipOffset": 6.0
       }
@@ -529,20 +529,12 @@
         "Name": "ベリウル(Beriul)",
         "Creator": "あまち(Amati)",
         "Introducer": "Heather May",
-        "Hash": ["573589805"],
+        "Hash": ["573589805", "-2078421954v2"],
         "Weight": 1,
         "WingtipOffset": 2.5
       }
     },
     "Nico the Floof": {
-      "Original": {
-        "Name": "Nico the Floof",
-        "Creator": "Alex The Cat",
-        "Introducer": "Heather May",
-        "Hash": ["1826494265"],
-        "Weight": 1,
-        "WingtipOffset": 7
-      },
       "Brin Solace Alteration": {
         "Name": "Nico the Floof",
         "Creator": "Alex The Cat",
@@ -557,7 +549,7 @@
         "Name": "Petrenkavali (Petvali)",
         "Creator": "Stormi Starcrest / Petrenko",
         "Introducer": "Heather May",
-        "Hash": ["-114915416"],
+        "Hash": ["-114915416", "-1706856203v2"],
         "Weight": 1,
         "WingtipOffset": 4.58
       }
@@ -567,7 +559,7 @@
         "Name": "VRaptor",
         "Creator": "Spaghet / Kaelygon",
         "Introducer": "Heather May",
-        "Hash": ["-1366154542"],
+        "Hash": ["-1366154542", "599890630v2"],
         "Weight": 1,
         "WingtipOffset": 0.0
       }

--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -535,6 +535,14 @@
       }
     },
     "Nico the Floof": {
+      "Original": {
+        "Name": "Nico the Floof (Deira Base)",
+        "Creator": "Alex The Cat",
+        "Introducer": "Heather May",
+        "Hash": ["1826494265", "1026958829v2"],
+        "Weight": 1,
+        "WingtipOffset": 7
+      },
       "Brin Solace Alteration": {
         "Name": "Nico the Floof",
         "Creator": "Alex The Cat",


### PR DESCRIPTION
* Added V2 hashes for numerous entries
* Updated Introducer for Flute v1.1 and v2 to make tracking the models down easier in the future if needed.
* Removed base Nico the Floof. This uses an unmodified Deira rig.