### PR TITLE
Added entries for ZWyvern and Nardovern

### DIFF
--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -597,7 +597,7 @@
         "Name": "ZWyvern",
         "Creator": "Morghus",
         "Introducer": "Literally Marty",
-        "Hash": ["1257052648"],
+        "Hash": ["-843246621v2"],
         "Weight": 1,
         "WingtipOffset": 10.2
       }
@@ -607,7 +607,7 @@
         "Name": "Nardovern",
         "Creator": "Morghus",
         "Introducer": "Literally Marty",
-        "Hash": ["1318433413"],
+        "Hash": ["518712631v2"],
         "Weight": 1,
         "WingtipOffset": 10.25
       }

--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -591,6 +591,26 @@
         "Weight": 1,
         "WingtipOffset": 10.5
       }
+    },
+    "ZWyvern": {
+      "ZWyvern": {
+        "Name": "ZWyvern",
+        "Creator": "Morghus",
+        "Introducer": "Literally Marty",
+        "Hash": ["1257052648"],
+        "Weight": 1,
+        "WingtipOffset": 10.2
+      }
+    },
+    "Nardovern": {
+      "Nardovern": {
+        "Name": "Nardovern",
+        "Creator": "Morghus",
+        "Introducer": "Literally Marty",
+        "Hash": ["1318433413"],
+        "Weight": 1,
+        "WingtipOffset": 10.25
+      }
     }
   }
 }


### PR DESCRIPTION
Added entries for both the [ZWyvern](https://morghus.gumroad.com/l/zwyvern) and [Nardovern](https://morghus.gumroad.com/l/nardovern) by Morghus. These are publicly available edits of the [ZDragon](https://zephyxus.gumroad.com/l/zdragon) and [Nardoragon](https://nardoiri.gumroad.com/l/Nardoragon) that integrate wings into the arms.