### PR TITLE
Match data.json location in Udon to prefab

### DIFF
--- a/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarListLoader.cs
+++ b/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarListLoader.cs
@@ -9,7 +9,7 @@ namespace OpenFlightVRC
 {
 	public class AvatarListLoader : UdonSharpBehaviour
 	{
-		public VRCUrl URL = new VRCUrl("https://mattshark89.github.io/OpenFlight-VRC/Assets/OpenFlight-VRC/data.json");
+		public VRCUrl URL = new VRCUrl("https://mattshark89.github.io/OpenFlight-VRC/data.json");
 
 		/// <summary>
 		/// The output of the json file. This is set by the <see cref="LoadURL"/> method, and is done asynchronously, so make sure your script waits for output to be set. See VRCStringDownloader for more information


### PR DESCRIPTION
This is the URL that the system is trying to query for data.json:
https://github.com/Mattshark89/OpenFlight-VRC/blob/683a0b093c24d67aceeb563928f3b7cf3a87f549/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarListLoader.cs#L12-L13

This is the URL I was actually able to find data.json at: https://mattshark89.github.io/OpenFlight-VRC/data.json

This PR relocates the file to match where the Udon script is looking, my test shows up at https://kitl.pw/OpenFlight-VRC/Assets/OpenFlight-VRC/data.json

Grain of salt, I've not tested this PR in-game myself yet, because I didn't feel like throwing together a world to upload to test this.