### PR TITLE
Added missing hash for Krazen Nardovern

### DIFF
--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./data_schema.json",
-  "JSON Version": "1.12.0",
-  "JSON Date": "2023-10-03",
+  "JSON Version": "1.12.1",
+  "JSON Date": "2023-10-04",
   "Contributers": ["Happyrobot33", "Mattshark89", "DatGek", "Heather May", "mackandelius", "Morghus", "Krazen", "fundale", "Literally Marty", "Roimu", "Daernaro"],
   "Bases": {
     "Kitavali": {
@@ -773,9 +773,9 @@
         "Name": "Krazen Nardovern - Toggleable Wings",
         "Creator": "Krazen / Morghus",
         "Introducer": "Krazen",
-        "Hash": ["00v2"],
+        "Hash": ["1967967830v2"],
         "Weight": 1,
-        "WingtipOffset": 10.25
+        "WingtipOffset": 10.45
       }
     },
     "Guavali": {


### PR DESCRIPTION
Now that the avatar has been updated to generate a new hash that differs from default Nardos, this can be updated accordingly.