### PR TITLE
ci: minify the data.json when publishing the website

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -67,7 +67,12 @@ jobs:
         uses: canastro/copy-action@0.0.2
         with:
           source: "./Packages/com.mattshark.openflight/Runtime/data.json"
-          target: "./${{env.listPublishDirectory}}/data.json"
+          target: "./${{env.listPublishDirectory}}/data-original.json"
+
+      # Makes the file smaller for everyone to download
+      - name: Minify and copy data.json
+        run: jq -r tostring ./${{env.listPublishDirectory}}/data-original.json > ./${{env.listPublishDirectory}}/data.json
+
 
       #Generate the doxygen documentation
       - name: Generate C# Documentation


### PR DESCRIPTION
This reduces the size of the string, reducing the download size and making more headroom concerning the vrc string size limit.

I tested by changing the url to a custom one hosting the minified version and the detection is working.

Unity 2022.3.22f1, OpenFlight 1.7.3 installed from VCC.