### PR TITLE
Improve formatting of present date.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -38,11 +38,8 @@
           methods: {
             formatDate() {
               date = new Date();
-              day = date.getUTCDate();
-              month = date.getUTCMonth() + 1;
-              year = date.getUTCFullYear();
 
-              return `${year}-${month}-${day}`;
+              return date.toISOString().split('T')[0];
             }
           },
         }


### PR DESCRIPTION
Was described as `YYYY-MM-DD`, but was able to show single digits for month and date. Thought initially to naively introduce padding with 0s; however, can instead just get the full ISO 8601 datetime from `.toISOString()` (which is always in UTC by definition) and split off and return the date part.

As in, was seeing `2024-9-7`:

![image](https://github.com/user-attachments/assets/4c76737c-dd45-422b-bbb0-0afeba53a56b)

But if I'm understanding how the docs are built, with the change from this  PR, should now display the full `2024-09-07`.