### PR TITLE
Change Arkeo's Nox Wyvern hash

### DIFF
--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./data_schema.json",
-  "JSON Version": "2.45.0",
-  "JSON Date": "2025-03-28",
+  "JSON Version": "2.46.0",
+  "JSON Date": "2025-03-31",
   "Contributers": [
     "ItsFloofy",
     "Daernaro",

--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -1507,7 +1507,7 @@
         "Creator": "Arkeo / Fluff Rali",
         "Introducer": "ArkeoTP",
         "Hash": [
-          "-158982699v2"
+          "809825900v2"
         ],
         "Weight": 1,
         "WingtipOffset": 7.0

--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./data_schema.json",
-  "JSON Version": "2.46.0",
+  "JSON Version": "2.45.1",
   "JSON Date": "2025-03-31",
   "Contributers": [
     "ItsFloofy",


### PR DESCRIPTION
The previous hash had the unfortunate property of being identical to the default Nox Dragon which is definitely not intentional.