### PR TITLE
[Avatar Addition] Rootoohoo

### DIFF
--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./data_schema.json",
   "JSON Version": "2.49.0",
-  "JSON Date": "2025-04-25",
+  "JSON Date": "2025-04-28",
   "Contributers": [
     "ItsFloofy",
     "Daernaro",
@@ -1900,7 +1900,7 @@
         "Creator": "zombies-in-soup/TrueHiddenS",
         "Introducer": "TrueHiddenS",
         "Hash": [
-          "-1897602366v2"
+          "-2053657869v2"
         ],
         "Weight": 1,
         "WingtipOffset": 1.5

--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./data_schema.json",
   "JSON Version": "2.49.0",
-  "JSON Date": "2025-04-28",
+  "JSON Date": "2025-05-05",
   "Contributers": [
     "ItsFloofy",
     "Daernaro",
@@ -1895,8 +1895,8 @@
       }
     },
     "RooTooHoo": {
-      "RooToo Texture Edit/Mesh addition": {
-        "Name": "Tru Snowy RooToo (4.0)",
+      "RooTooHoo Wings Edit": {
+        "Name": "Tru Snowy RooTooHoo (4.0)",
         "Creator": "zombies-in-soup/TrueHiddenS",
         "Introducer": "TrueHiddenS",
         "Hash": [
@@ -1905,4 +1905,6 @@
         "Weight": 1,
         "WingtipOffset": 1.5
      }
-    },
+    }
+  }
+}

--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./data_schema.json",
-  "JSON Version": "2.48.0",
-  "JSON Date": "2025-04-23",
+  "JSON Version": "2.49.0",
+  "JSON Date": "2025-04-25",
   "Contributers": [
     "ItsFloofy",
     "Daernaro",
@@ -54,7 +54,8 @@
     "Apache Longbow",
     "Ordinary_night",
     "a distraction",
-    "Mieze"
+    "Mieze",
+    "TrueHiddenS"
   ],
   "Bases": {
     "Kitavali": {
@@ -1892,6 +1893,16 @@
         "Weight": 1,
         "WingtipOffset": 2.1
       }
-    }
-  }
-}
+    },
+    "RooTooHoo": {
+      "RooToo Texture Edit/Mesh addition": {
+        "Name": "Tru Snowy RooToo (4.0)",
+        "Creator": "zombies-in-soup/TrueHiddenS",
+        "Introducer": "TrueHiddenS",
+        "Hash": [
+          "-1897602366v2"
+        ],
+        "Weight": 1,
+        "WingtipOffset": 1.5
+     }
+    },


### PR DESCRIPTION
A texture edit of a avatar base created by zombies_in_soup complete with added wings using an added mesh made by me with guidance from my friend Lychee-Lily, below are pictures of said Rootoohoo with wings beginning from the hand.
![VRChat_2025-04-25_18-38-44 646_1920x1080](https://github.com/user-attachments/assets/baa08a0f-c344-49e5-bdf6-13b5beb35947)
![VRChat_2025-04-25_18-39-02 573_1920x1080](https://github.com/user-attachments/assets/9d7e9685-a61a-4449-9ec1-ce53d458938f)
![VRChat_2025-04-25_18-39-20 585_1920x1080](https://github.com/user-attachments/assets/0ad8d7f9-09d9-4153-bace-87fc72b7419d)
![VRChat_2025-04-25_18-56-11 788_1920x1080](https://github.com/user-attachments/assets/78ca2ea4-e1a4-485f-8b12-9e5d6f490b5c)

Also here are the links for the original base made by zombies_in_soup
https://zombies-in-soup.gumroad.com/l/rootoo?layout=profile
https://zombies.booth.pm/items/3439419