### PR TITLE
Fix incorrect base name

### DIFF
--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./data_schema.json",
-  "JSON Version": "2.54.0",
-  "JSON Date": "2025-06-10",
+  "JSON Version": "2.54.1",
+  "JSON Date": "2025-06-16",
   "Contributers": [
     "ItsFloofy",
     "Daernaro",
@@ -1861,7 +1861,7 @@
         "WingtipOffset": 3.25
       }
     },
-    "パーレ": {
+    "つくね": {
       "Original": {
         "Name": "Tsukune",
         "Creator": "udon-cat-works",


### PR DESCRIPTION
The "パーレ" base added in PR https://github.com/Mattshark89/OpenFlight-VRC/pull/138 should have been named "つくね". (The display name "Tsukune" is already correct.)

See the original base (also linked in the PR): https://udon-cat-works.booth.pm/items/5064636