### PR TITLE
Fix particle shader error

### DIFF
--- a/Packages/com.mattshark.openflight/Runtime/Materials/Particles.shader
+++ b/Packages/com.mattshark.openflight/Runtime/Materials/Particles.shader
@@ -45,7 +45,7 @@ Shader "OpenFlight/Particles"
                     o.uv0 = v.texcoord0;
                     o.vertex = UnityObjectToClipPos(v.vertex);
                     o.color = v.color;
-                    UNITY_TRANSFER_FOG(o,o.pos);
+                    UNITY_TRANSFER_FOG(o,o.vertex);
                     return o;
                 }
                 


### PR DESCRIPTION
The particle shader refers to `o.pos` but it doesn't exist in the given structure. Instead we should be using `o.vertex` (... I think)