### PR TITLE
Work around a race condition with PoolController and EventHandler

### DIFF
--- a/Packages/com.mattshark.openflight/Runtime/Scripts/Networking/PoolController.cs
+++ b/Packages/com.mattshark.openflight/Runtime/Scripts/Networking/PoolController.cs
@@ -33,8 +33,25 @@ namespace OpenFlightVRC.Net
 
 		private EffectsHandler[] _effectHandlers = new EffectsHandler[0];
 
-		void Update()
+		private bool initialized = false;
+
+        void Start()
+        {
+			//WORKAROUND: there's a race condition on scene load so default VFX toggles work
+			// Tried to force hander.VFX = VFX after 1s, but any touching of the properties too early causes them to 'stick' in EffectsHandler until they are fully toggled
+			// So we're using a full initialization check here instead. The actual solution is probably reworking EffectsHandler setters.
+			// -Micca
+            SendCustomEventDelayedSeconds(nameof(_Initialize),1f);
+        }
+
+		public void _Initialize() {
+			initialized = true;
+		}
+
+        void Update()
 		{
+			if (!initialized) return; 
+			
 			//TODO: make this not run every frame, and instead do it on property change
 			//gotta figure out why GetProgramVariable doesnt like propertys
 			if (_SFX_OLD == SFX && _VFX_OLD == VFX && _volume_OLD == volume)

--- a/Packages/com.mattshark.openflight/Runtime/Scripts/Networking/PoolController.cs
+++ b/Packages/com.mattshark.openflight/Runtime/Scripts/Networking/PoolController.cs
@@ -41,7 +41,7 @@ namespace OpenFlightVRC.Net
 			// Tried to force hander.VFX = VFX after 1s, but any touching of the properties too early causes them to 'stick' in EffectsHandler until they are fully toggled
 			// So we're using a full initialization check here instead. The actual solution is probably reworking EffectsHandler setters.
 			// -Micca
-            SendCustomEventDelayedSeconds(nameof(_Initialize),1f);
+            SendCustomEventDelayedSeconds(nameof(_Initialize),3f);
         }
 
 		public void _Initialize() {


### PR DESCRIPTION
Fixes #135

This isn't a great solution, the actual solution is to probably rework the setters in EffectsHandler, but given the rewrite going on [I believe?], this might be the simplest work around for now.