### PR TITLE
[Avatar Addition] Spiri'vali Taur

### DIFF
--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./data_schema.json",
   "JSON Version": "2.65.0",
-  "JSON Date": "2025-11-03",
+  "JSON Date": "2025-11-04",
   "Contributers": [
     "ItsFloofy",
     "Daernaro",


### PR DESCRIPTION
Adding a taur edit of Hiyu's Spiri'vali avatar base to the mix. The edit is available for free to anyone who has purchased the Spiri'vali base, and it can be found in the Spirivali Society discord in the file sharing section.