### PR TITLE
Fix JSON loader race condition & Add Optional Cooldown

### DIFF
--- a/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarDetection.cs
+++ b/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarDetection.cs
@@ -140,8 +140,6 @@ namespace OpenFlightVRC
 
 			debugInfo = "Loading JSON list...";
 			JSONLoader.AddCallback(AvatarListLoaderCallback.AvatarListLoaded, this, nameof(LoadJSON));
-
-			JSONLoader.SendCustomEventDelayedFrames(nameof(AvatarListLoader.LoadURL), 1); // 1 frame delay to prevent a race condition where the offline callback is triggered before other scripts could register
 		}
 
 		public override void OnAvatarChanged(VRCPlayerApi player)

--- a/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarDetection.cs
+++ b/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarDetection.cs
@@ -141,7 +141,7 @@ namespace OpenFlightVRC
 			debugInfo = "Loading JSON list...";
 			JSONLoader.AddCallback(AvatarListLoaderCallback.AvatarListLoaded, this, nameof(LoadJSON));
 
-			JSONLoader.LoadURL();
+			JSONLoader.SendCustomEventDelayedFrames(nameof(AvatarListLoader.LoadURL), 1); // 1 frame delay to prevent a race condition where the offline callback is triggered before other scripts could register
 		}
 
 		public override void OnAvatarChanged(VRCPlayerApi player)

--- a/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarListLoader.cs
+++ b/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarListLoader.cs
@@ -48,36 +48,28 @@ namespace OpenFlightVRC
 		/// </summary>
 		public void LoadURL()
 		{
-            if (LoadDelay > 0)
-            {
-                SendCustomEventDelayedSeconds(nameof(DelayedLoadURL), LoadDelay);
-            }
-            else
-            {
-	            SendCustomEventDelayedFrames(nameof(DelayedLoadURL), 1); // Prevents race condition when applying the OfflineJson before other scripts could register.
-            }
+			SendCustomEventDelayedFrames(nameof(LoadOfflineJson), 1); // Prevents race condition when applying the OfflineJson before other scripts could register.
+
+			if (!useOfflineJSON)
+				SendCustomEventDelayedSeconds(nameof(DelayedLoadURL), LoadDelay);
+		}
+
+		/// <summary>
+		/// Loads and applies the in-world JSON file.
+		/// </summary>
+		public void LoadOfflineJson()
+		{
+			Output = OfflineJSON.text;
+			Logger.Log("Loading in-world JSON list.", this);
+			RunCallback(AvatarListLoaderCallback.AvatarListLoaded);
 		}
 
         /// <summary>
-        /// Loads the URL and sets the Output property. Only used internally after a delay.
+        /// Starts the URL Loading Process. Only used internally after a delay.
         /// </summary>
         public void DelayedLoadURL()
         {
-            Output = "";
-
-            if (useOfflineJSON)
-            {
-                Output = OfflineJSON.text;
-                Logger.Log("Force-using in-world JSON list", this);
-                RunCallback(AvatarListLoaderCallback.AvatarListLoaded);
-                return;
-            }
-
-            //initially trigger with the in-world list
-            Output = OfflineJSON.text;
-            Logger.Log("Using in-world JSON list until remote is available....", this);
-            RunCallback(AvatarListLoaderCallback.AvatarListLoaded);
-
+	        Logger.Log("Loading Avatar List URL...", this);
             VRCStringDownloader.LoadUrl(URL, (VRC.Udon.Common.Interfaces.IUdonEventReceiver)this);
         }
 
@@ -92,9 +84,8 @@ namespace OpenFlightVRC
 		//if the URL fails to load, fallback to the in-world stored JSON instead
 		public override void OnStringLoadError(IVRCStringDownload data)
 		{
-			Output = OfflineJSON.text;
 			Logger.Log("Failed to load Avatar List URL! Using in-world JSON instead.", this);
-			RunCallback(AvatarListLoaderCallback.AvatarListLoaded);
+			LoadOfflineJson();
 		}
 	}
 

--- a/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarListLoader.cs
+++ b/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarListLoader.cs
@@ -48,26 +48,19 @@ namespace OpenFlightVRC
 		/// </summary>
 		public void LoadURL()
 		{
-			SendCustomEventDelayedFrames(nameof(LoadOfflineJson), 1); // Prevents race condition when applying the OfflineJson before other scripts could register.
-
-			if (!useOfflineJSON)
-				SendCustomEventDelayedSeconds(nameof(DelayedLoadURL), LoadDelay);
-		}
-
-		/// <summary>
-		/// Loads and applies the in-world JSON file.
-		/// </summary>
-		public void LoadOfflineJson()
-		{
+			// Fill with the in-world JSON first
 			Output = OfflineJSON.text;
 			Logger.Log("Loading in-world JSON list.", this);
 			RunCallback(AvatarListLoaderCallback.AvatarListLoaded);
+			
+			if (!useOfflineJSON)
+				SendCustomEventDelayedSeconds(nameof(StartUrlLoadingDelayed), LoadDelay);
 		}
 
         /// <summary>
-        /// Starts the URL Loading Process. Only used internally after a delay.
+        /// Starts the actual URL loading process. Only used internally.
         /// </summary>
-        public void DelayedLoadURL()
+        public void StartUrlLoadingDelayed()
         {
 	        Logger.Log("Loading Avatar List URL...", this);
             VRCStringDownloader.LoadUrl(URL, (VRC.Udon.Common.Interfaces.IUdonEventReceiver)this);
@@ -84,8 +77,9 @@ namespace OpenFlightVRC
 		//if the URL fails to load, fallback to the in-world stored JSON instead
 		public override void OnStringLoadError(IVRCStringDownload data)
 		{
+			Output = OfflineJSON.text;
 			Logger.Log("Failed to load Avatar List URL! Using in-world JSON instead.", this);
-			LoadOfflineJson();
+			RunCallback(AvatarListLoaderCallback.AvatarListLoaded);
 		}
 	}
 

--- a/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarListLoader.cs
+++ b/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarListLoader.cs
@@ -2,6 +2,7 @@
  * @ Maintainer: Happyrobot33
  */
 
+using System;
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
@@ -28,7 +29,7 @@ namespace OpenFlightVRC
 		public float LoadDelay = 0f;
 
 		/// <summary>
-		/// The output of the json file. This is set by the <see cref="LoadURL"/> method, and is done asynchronously, so make sure your script waits for output to be set. See VRCStringDownloader for more information
+		/// The output of the json file. This is set by the <see cref="LoadURL"/> or <see cref="LoadURLDelayed"/> method, and is done asynchronously, so make sure your script waits for output to be set. See VRCStringDownloader for more information
 		/// </summary>
 		[System.NonSerialized]
 		public string Output = "";
@@ -43,24 +44,48 @@ namespace OpenFlightVRC
 		/// </summary>
 		public bool useOfflineJSON = false;
 
+
+		private void Start()
+		{
+			SendCustomEventDelayedFrames(nameof(LoadURLDelayed), 1); // prevents a race condition when trying to apply the offline JSON before all scripts could register for the callback
+		}
+
 		/// <summary>
-		/// Starts the URL loading processes and sets the Output property once done. This is done asynchronously, so make sure your script waits for output to be set. See VRCStringDownloader for more information.
+		/// Starts the URL loading processes and sets the Output property once done. This is done asynchronously, so make sure your script waits for output to be set. See <see cref="VRCStringDownloader"/> for more information.
 		/// </summary>
 		public void LoadURL()
 		{
-			// Fill with the in-world JSON first
+			LoadOfflineJson();
+			
+			if (!useOfflineJSON)
+				LoadRemoteString();
+		}
+
+		/// <summary>
+		/// Starts the URL loading processes after a delay and sets the Output property once done. This is done asynchronously, so make sure your script waits for output to be set. See <see cref="VRCStringDownloader"/> for more information.
+		/// </summary>
+		public void LoadURLDelayed()
+		{
+			LoadOfflineJson();
+			
+			if (!useOfflineJSON)
+				SendCustomEventDelayedSeconds(nameof(LoadRemoteString), LoadDelay);
+		}
+		
+		/// <summary>
+		/// Applies the in-world JSON to the Output property. And triggers the <see cref="AvatarListLoaderCallback.AvatarListLoaded"/> callback.
+		/// </summary>
+		public void LoadOfflineJson()
+		{
 			Output = OfflineJSON.text;
 			Logger.Log("Loading in-world JSON list.", this);
 			RunCallback(AvatarListLoaderCallback.AvatarListLoaded);
-			
-			if (!useOfflineJSON)
-				SendCustomEventDelayedSeconds(nameof(StartUrlLoadingDelayed), LoadDelay);
 		}
-
+		
         /// <summary>
-        /// Starts the actual URL loading process. Only used internally.
+        /// Starts the actual string loading process. Only used internally.
         /// </summary>
-        public void StartUrlLoadingDelayed()
+        public void LoadRemoteString()
         {
 	        Logger.Log("Loading Avatar List URL...", this);
             VRCStringDownloader.LoadUrl(URL, (VRC.Udon.Common.Interfaces.IUdonEventReceiver)this);
@@ -74,12 +99,11 @@ namespace OpenFlightVRC
 			RunCallback(AvatarListLoaderCallback.AvatarListLoaded);
 		}
 
-		//if the URL fails to load, fallback to the in-world stored JSON instead
+		// If the URL fails to load, fallback to the in-world stored JSON instead.
 		public override void OnStringLoadError(IVRCStringDownload data)
 		{
-			Output = OfflineJSON.text;
 			Logger.Log("Failed to load Avatar List URL! Using in-world JSON instead.", this);
-			RunCallback(AvatarListLoaderCallback.AvatarListLoaded);
+			LoadOfflineJson();
 		}
 	}
 

--- a/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarListLoader.cs
+++ b/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarListLoader.cs
@@ -21,12 +21,18 @@ namespace OpenFlightVRC
 	public class AvatarListLoader : CallbackUdonSharpBehaviour
 	{
 		public VRCUrl URL = new VRCUrl("https://mattshark89.github.io/OpenFlight-VRC/data.json");
+		
+		/// <summary>
+		/// The time to wait in seconds before starting the download.
+		/// </summary>
+		public float LoadDelay = 0f;
 
 		/// <summary>
 		/// The output of the json file. This is set by the <see cref="LoadURL"/> method, and is done asynchronously, so make sure your script waits for output to be set. See VRCStringDownloader for more information
 		/// </summary>
 		[System.NonSerialized]
 		public string Output = "";
+		
 		/// <summary>
 		/// The in-world json file. This is used if the URL fails to load
 		/// </summary>
@@ -38,27 +44,42 @@ namespace OpenFlightVRC
 		public bool useOfflineJSON = false;
 
 		/// <summary>
-		/// 	Loads the URL and sets the Output property. This is done asynchronously, so make sure your script waits for output to be set. See VRCStringDownloader for more information
+		/// Starts the URL loading processes and sets the Output property once done. This is done asynchronously, so make sure your script waits for output to be set. See VRCStringDownloader for more information.
 		/// </summary>
 		public void LoadURL()
 		{
-			Output = "";
-
-			if (useOfflineJSON)
-			{
-				Output = OfflineJSON.text;
-				Logger.Log("Force-using in-world JSON list", this);
-				RunCallback(AvatarListLoaderCallback.AvatarListLoaded);
-				return;
-			}
-
-			//initially trigger with the in-world list
-			Output = OfflineJSON.text;
-			Logger.Log("Using in-world JSON list until remote is available....", this);
-			RunCallback(AvatarListLoaderCallback.AvatarListLoaded);
-
-			VRCStringDownloader.LoadUrl(URL, (VRC.Udon.Common.Interfaces.IUdonEventReceiver)this);
+            if (LoadDelay > 0)
+            {
+                SendCustomEventDelayedSeconds(nameof(DelayedLoadURL), LoadDelay);
+            }
+            else
+            {
+	            SendCustomEventDelayedFrames(nameof(DelayedLoadURL), 1); // Prevents race condition when applying the OfflineJson before other scripts could register.
+            }
 		}
+
+        /// <summary>
+        /// Loads the URL and sets the Output property. Only used internally after a delay.
+        /// </summary>
+        public void DelayedLoadURL()
+        {
+            Output = "";
+
+            if (useOfflineJSON)
+            {
+                Output = OfflineJSON.text;
+                Logger.Log("Force-using in-world JSON list", this);
+                RunCallback(AvatarListLoaderCallback.AvatarListLoaded);
+                return;
+            }
+
+            //initially trigger with the in-world list
+            Output = OfflineJSON.text;
+            Logger.Log("Using in-world JSON list until remote is available....", this);
+            RunCallback(AvatarListLoaderCallback.AvatarListLoaded);
+
+            VRCStringDownloader.LoadUrl(URL, (VRC.Udon.Common.Interfaces.IUdonEventReceiver)this);
+        }
 
 		public override void OnStringLoadSuccess(IVRCStringDownload data)
 		{


### PR DESCRIPTION
This PR fixes a race condition when initially loading the Offline JSON that was caused due to the `AvatarListLoaderCallback.AvatarListLoaded` Callback *sometimes* being called before all scripts could register for it.

To remedy this I have:
- Added an initial 1 frame delay before starting the string load
- Added an optional Load Delay that is configurable in the inspector
-> This allows worlds to e.g. prioritize loading their own string before Open Flight does