### PR TITLE
Fix for WingtipOffset/weight being applied too soon

### DIFF
--- a/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarDetection.cs
+++ b/Packages/com.mattshark.openflight/Runtime/Scripts/Detection/AvatarDetection.cs
@@ -193,9 +193,6 @@ namespace OpenFlightVRC
 			//we need a accurate avatar scale for the hash to work
 			d_spinetochest = CalculateAvatarScale(out Vector3 spine, out Vector3 chest);
 
-			WingFlightPlusGlide.wingtipOffset = WingtipOffset;
-			WingFlightPlusGlide.weight = weight;
-
 			//get all the bones
 			Vector3 head = _localPlayer.GetBonePosition(HumanBodyBones.Head);
 			Vector3 neck = _localPlayer.GetBonePosition(HumanBodyBones.Neck);
@@ -226,6 +223,8 @@ namespace OpenFlightVRC
 				if (allowedToFly)
 				{
 					OpenFlight.CanFly();
+					WingFlightPlusGlide.wingtipOffset = WingtipOffset;
+					WingFlightPlusGlide.weight = weight;
 					Logger.Log("Avatar is allowed to fly!", this);
 				}
 				else

--- a/Packages/com.mattshark.openflight/Runtime/data.json
+++ b/Packages/com.mattshark.openflight/Runtime/data.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./data_schema.json",
-  "JSON Version": "2.84.0",
-  "JSON Date": "2026-07-19",
+  "JSON Version": "2.85.0",
+  "JSON Date": "2026-08-09",
   "Contributers": [
     "ItsFloofy",
     "Daernaro",
@@ -82,7 +82,8 @@
     "KuroFoxYokai",
     "DrBlackRat",
     "kitofox",
-    "Mawterwelon"
+    "Mawterwelon",
+    "Icyvarix"
   ],
   "Bases": {
     "Kitavali": {


### PR DESCRIPTION
The WingtipOffset/weight avatar modifiers are copied to the actual physics module before IsAvatarAllowedToFly is called, which is where those values are actually fetched from the avatar data.  This means the values the physics system gets are the values the detection system had cached from the previous update.

I tested with debug statements that print out the physics values at the end of the detection function, but also tried live testing it and it's for sure happening.

To test:

Use the Nardobat with 1.71 height
Set flap strength to 170

Baseline:
Load into one Nardobat and then into a separate Nardobat, so you're using the actual Nardobat values
Try to fly only by flapping.  It's not trivial, but it's doable

Issue:
Load into a non-flying avatar and then back into the Nardobat
Try to fly only by flapping.  Good luck.



Look at me I contributed.